### PR TITLE
chore(build): use latest maven central url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
         <repository>
             <id>central</id>
-            <url>https://repo1.maven.org/maven2/</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -52,7 +52,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>central</id>
-            <url>https://repo1.maven.org/maven2/</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
I just found that the default maven central url in[ the latest super pom](http://maven.apache.org/ref/3.6.0/maven-model-builder/super-pom.html) is `https://repo.maven.apache.org/maven2` 

It's also said here https://maven.apache.org/guides/mini/guide-mirror-settings.html

```
Note: The official Maven 2 repository is at https://repo.maven.apache.org/maven2http://repo.maven.apache.org/maven2 hosted in the US, or http://uk.maven.org/maven2 hosted in the UK.
```
Connect to #46 
Follow up #52 