### PR TITLE
chore(script): show output console more verbose

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
   <title>Vaadin Connect demo</title>
 </head>
 <body>
+
   <!-- The page content is added dynamically by `index.js`. -->
 
   <!-- Polyfills for the Web Component APIs are required to use vaadin-button and other Web Components
@@ -14,7 +15,7 @@
   <!-- A polyfill for the `fetch` API is required to use Vaadin Connect
        in the browsers that do not support this API natively (e.g. IE11) -->
   <script nomodule src="polyfills.es5.js"></script>
-
+  
   <!-- index.js is included here automatically (either by the dev server or during the build) -->
 </body>
 </html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -9,4 +9,5 @@ async function main() {
   await loginController.loginAction();
   new StatusController(new StatusView(document.body));
 }
+
 main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,14 +3835,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3857,20 +3855,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3987,8 +3982,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4000,7 +3994,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4015,7 +4008,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4023,14 +4015,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4049,7 +4039,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4130,8 +4119,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4143,7 +4131,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4265,7 +4252,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "Base"
   ],
   "scripts": {
-    "build:frontend": "webpack --progress",
+    "build:frontend": "webpack",
     "build": "./mvnw package",
     "start:backend": "node scripts/start/backend.js",
-    "start:webpack": "node scripts/start/webpack.js",
+    "start:webpack": "webpack --mode development --progress --silent --watch",
     "start:apibrowser": "node scripts/start/apibrowser.js",
-    "start": "npm run start:backend -- -- npm run start:apibrowser -- -- npm run start:webpack",
+    "start": "npm --silent run start:backend -- -- npm --silent run start:apibrowser -- -- npm --silent run start:webpack",
     "test:unit": "node $NODE_DEBUG_OPTION ./node_modules/.bin/intern environments=node functionalSuites=",
     "test:e2e": "node $NODE_DEBUG_OPTION ./node_modules/.bin/intern",
     "test": "npm run test:unit && npm run build:frontend && npm run start:backend -- --nowatch -- npm run test:e2e"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "Base"
   ],
   "scripts": {
-    "build:frontend": "webpack",
+    "build:frontend": "webpack --progress",
     "build": "./mvnw package",
     "start:backend": "node scripts/start/backend.js",
-    "start:webpack": "webpack --mode development -w",
+    "start:webpack": "node scripts/start/webpack.js",
     "start:apibrowser": "node scripts/start/apibrowser.js",
     "start": "npm run start:backend -- -- npm run start:apibrowser -- -- npm run start:webpack",
     "test:unit": "node $NODE_DEBUG_OPTION ./node_modules/.bin/intern environments=node functionalSuites=",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:frontend": "webpack",
     "build": "./mvnw package",
     "start:backend": "node scripts/start/backend.js",
-    "start:webpack": "webpack --mode development --progress --silent --watch",
+    "start:webpack": "webpack --mode development --progress --silent --info-verbosity none --watch",
     "start:apibrowser": "node scripts/start/apibrowser.js",
     "start": "npm --silent run start:backend -- -- npm --silent run start:apibrowser -- -- npm --silent run start:webpack",
     "test:unit": "node $NODE_DEBUG_OPTION ./node_modules/.bin/intern environments=node functionalSuites=",

--- a/pom.xml
+++ b/pom.xml
@@ -293,11 +293,16 @@
                         <artifactId>exec-maven-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>npm-install</id>
                                 <phase>validate</phase>
                                 <goals><goal>exec</goal></goals>
                                 <configuration>
                                     <executable>npm</executable>
-                                    <arguments><argument>install</argument></arguments>
+                                    <arguments>
+                                        <argument>install</argument>
+                                        <argument>--loglevel</argument>
+                                        <argument>info</argument>
+                                    </arguments>
                                 </configuration>
                             </execution>
                         </executions>

--- a/scripts/start/apibrowser.js
+++ b/scripts/start/apibrowser.js
@@ -4,7 +4,7 @@ const httpProxy = require('http-proxy-middleware');
 const fs = require('fs');
 
 const CONNECT_API_HOSTNAME = process.env.CONNECT_API_HOSTNAME || 'localhost';
-const BACKEND = process.env.BACKEND || `http://${CONNECT_API_HOSTNAME}:8080`;
+const BACKEND = process.env.CONNECT_BACKEND || `http://${CONNECT_API_HOSTNAME}:8080`;
 const CONNECT_API_PORT = process.env.CONNECT_API_PORT || 8082;
 let url;
 

--- a/scripts/start/apibrowser.js
+++ b/scripts/start/apibrowser.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const BACKEND = 'http://localhost:8080';
 const CONNECT_API_HOSTNAME = process.env.CONNECT_API_HOSTNAME || 'localhost';
 const CONNECT_API_PORT = process.env.CONNECT_API_PORT || 8082;
+let url;
 
 const backend = makeProxyApp(BACKEND);
 const backendEndpoints = [
@@ -45,7 +46,7 @@ function renderOpenApiHtml() {
           requestInterceptor: request => {
             request.url = request.url.replace(
               '${BACKEND}',
-              'http://${CONNECT_API_HOSTNAME}:${CONNECT_API_PORT}'
+              '${url}'
             );
             return request;
           },
@@ -69,10 +70,12 @@ const server = require('http').createServer(app);
 server.listen(CONNECT_API_PORT, CONNECT_API_HOSTNAME, () => {
   const {address, port} = server.address();
   const hostname = CONNECT_API_HOSTNAME || address;
-  const url = new URL(`http://${hostname}:${port}`);
-  console.log(`Started Vaadin Connect OpenApi UI at: ${url}`);
+  url = new URL(`http://${hostname}:${port}`);
+
+  console.log(`======== Vaadin Connect OpenApi UI is running at: ${url} ========`);
+
   if (chainedExecutable) {
-    chainedArgs.push('--env.connectApiBrowser=http://localhost:8082');
+    chainedArgs.push(`--env.connectApiBrowser=${url}`);
     const chainedProcess = spawn(
       chainedExecutable,
       chainedArgs,

--- a/scripts/start/apibrowser.js
+++ b/scripts/start/apibrowser.js
@@ -72,6 +72,7 @@ server.listen(CONNECT_API_PORT, CONNECT_API_HOSTNAME, () => {
   const url = new URL(`http://${hostname}:${port}`);
   console.log(`Started Vaadin Connect OpenApi UI at: ${url}`);
   if (chainedExecutable) {
+    chainedArgs.push('--env.connectApiBrowser=http://localhost:8082');
     const chainedProcess = spawn(
       chainedExecutable,
       chainedArgs,

--- a/scripts/start/apibrowser.js
+++ b/scripts/start/apibrowser.js
@@ -1,11 +1,10 @@
-const {URL} = require('url');
 const {spawn} = require('child_process');
 const express = require('express');
 const httpProxy = require('http-proxy-middleware');
 const fs = require('fs');
 
-const BACKEND = 'http://localhost:8080';
 const CONNECT_API_HOSTNAME = process.env.CONNECT_API_HOSTNAME || 'localhost';
+const BACKEND = process.env.BACKEND || `http://${CONNECT_API_HOSTNAME}:8080`;
 const CONNECT_API_PORT = process.env.CONNECT_API_PORT || 8082;
 let url;
 
@@ -70,12 +69,12 @@ const server = require('http').createServer(app);
 server.listen(CONNECT_API_PORT, CONNECT_API_HOSTNAME, () => {
   const {address, port} = server.address();
   const hostname = CONNECT_API_HOSTNAME || address;
-  url = new URL(`http://${hostname}:${port}`);
+  url = `http://${hostname}:${port}`;
+  process.env.API = url;
 
-  console.log(`======== Vaadin Connect OpenApi UI is running at: ${url} ========`);
+  console.log(` 🌀  \x1b[36mVaadin Connect\x1b[0m OpenApi UI is running at: ${url}`);
 
   if (chainedExecutable) {
-    chainedArgs.push(`--env.connectApiBrowser=${url}`);
     const chainedProcess = spawn(
       chainedExecutable,
       chainedArgs,

--- a/scripts/start/backend.js
+++ b/scripts/start/backend.js
@@ -54,10 +54,11 @@ const [chainedExecutable, ...chainedArgs] = endOfOptionsIndex > -1
 execMaven(['compile', 'spring-boot:start', '-Dspring-boot.run.fork'], {async: true})
   .then(() => {
     process.on('exit', () => {
-      execMaven(['spring-boot:stop', '-Dspring-boot.stop.fork']);
+      execMaven(['spring-boot:stop', '-Dspring-boot.stop.fork'], {stdio: 'ignore', async: true});
     });
 
     if (chainedExecutable) {
+      chainedArgs.push('--', '--env.connectBackend=http://localhost:8080');
       return exec(chainedExecutable, chainedArgs, {async: true})
         .then(process.exit);
     }

--- a/scripts/start/backend.js
+++ b/scripts/start/backend.js
@@ -10,7 +10,6 @@
 const {spawn, execFileSync} = require('child_process');
 
 const exec = (cmd, args, options = {}) => {
-  console.log(cmd, args, options);
   options = Object.assign({stdio: 'inherit'}, options);
   if (options.async) {
     return new Promise((resolve, reject) => {

--- a/scripts/start/backend.js
+++ b/scripts/start/backend.js
@@ -8,6 +8,7 @@
  *   $ node scripts/start/backend.js -- echo "The backend is running..."
  */
 const {spawn, execFileSync} = require('child_process');
+const url = "http://localhost:8080/";
 
 const exec = (cmd, args, options = {}) => {
   options = Object.assign({stdio: 'inherit'}, options);
@@ -39,12 +40,6 @@ process.on('SIGBREAK', () => process.exit(0));
 process.on('SIGHUP', () => process.exit(129));
 process.on('SIGTERM', () => process.exit(137));
 
-// Java watcher
-if (process.argv.indexOf('--nowatch') < 0) {
-  execMaven(['fizzed-watcher:run'], {async: true})
-    .catch(process.exit);
-}
-
 // Server
 const endOfOptionsIndex = process.argv.indexOf('--');
 const [chainedExecutable, ...chainedArgs] = endOfOptionsIndex > -1
@@ -52,12 +47,21 @@ const [chainedExecutable, ...chainedArgs] = endOfOptionsIndex > -1
   : [];
 execMaven(['compile', 'spring-boot:start', '-Dspring-boot.run.fork'], {async: true})
   .then(() => {
-    process.on('exit', () => {
-      execMaven(['spring-boot:stop', '-Dspring-boot.stop.fork'], {stdio: 'ignore', async: true});
-    });
+    console.log();
+
+    // Java watcher
+    if (process.argv.indexOf('--nowatch') < 0) {
+      execMaven(['-q', 'fizzed-watcher:run'], {async: true})
+        .catch(process.exit);
+        console.log(` 🌀  \x1b[36mVaadin Connect\x1b[0m is watching for Java changes on ./src/main/java`);
+      }
+
+    console.log(` 🌀  \x1b[36mVaadin Connect\x1b[0m Backend is running at: ${url}`);
+
+    // Pass backend URL to API browser and webpack
+    process.env.BACKEND = url;
 
     if (chainedExecutable) {
-      chainedArgs.push('--', '--env.connectBackend=http://localhost:8080');
       return exec(chainedExecutable, chainedArgs, {async: true})
         .then(process.exit);
     }

--- a/scripts/start/backend.js
+++ b/scripts/start/backend.js
@@ -16,19 +16,17 @@ const exec = (cmd, args, options = {}) => {
     return new Promise((resolve, reject) => {
       const childProcess = spawn(cmd, args, options);
       // Ensure the child process is killed on shutdown
-      const killer = () => childProcess.kill();
-      process.addListener('exit', killer);
+      process.addListener('exit', childProcess.kill, {once: true});
       childProcess.on('exit', code => {
-        process.removeListener('exit', killer);
         if (code === 0) {
-          resolve(code);
+          resolve({code});
         } else {
-          reject(code);
+          reject({code});
         }
       });
     });
   } else {
-    return execFileSync(cmd, args, options);
+    execFileSync(cmd, args, options);
   }
 };
 
@@ -40,30 +38,38 @@ process.on('SIGBREAK', () => process.exit(0));
 process.on('SIGHUP', () => process.exit(129));
 process.on('SIGTERM', () => process.exit(137));
 
-// Server
-const endOfOptionsIndex = process.argv.indexOf('--');
-const [chainedExecutable, ...chainedArgs] = endOfOptionsIndex > -1
-  ? process.argv.slice(endOfOptionsIndex + 1)
-  : [];
-execMaven(['compile', 'spring-boot:start', '-Dspring-boot.run.fork'], {async: true})
-  .then(() => {
-    console.log();
+try {
+  console.log(`\n 🌀  \x1b[36mVaadin Connect\x1b[0m Backend is starting ... \n`);
+  execMaven(['compile', 'spring-boot:start', '-Dspring-boot.run.fork']);
+  console.log(`\n 🌀  \x1b[36mVaadin Connect\x1b[0m Backend is running at: ${url}`);
 
-    // Java watcher
-    if (process.argv.indexOf('--nowatch') < 0) {
-      execMaven(['-q', 'fizzed-watcher:run'], {async: true})
-        .catch(process.exit);
-        console.log(` 🌀  \x1b[36mVaadin Connect\x1b[0m is watching for Java changes on ./src/main/java`);
-      }
+  // At this point spring-boot has successfully started as a daemon
+  // We need to assure that we do not leave it running on exit.
+  process.addListener('exit', () => {
+    execMaven(['-q', 'spring-boot:stop'], {stdio: 'ignore', async: true});
+  }, {once: true});
 
-    console.log(` 🌀  \x1b[36mVaadin Connect\x1b[0m Backend is running at: ${url}`);
+  // Pass backend URL to other processes
+  process.env.CONNECT_BACKEND = url;
 
-    // Pass backend URL to API browser and webpack
-    process.env.BACKEND = url;
+  // Run the Java watcher
+  if (process.argv.indexOf('--nowatch') < 0) {
+    execMaven(['-q', 'fizzed-watcher:run'], {async: true})
+      .catch(process.exit);
+    console.log(` 🌀  \x1b[36mVaadin Connect\x1b[0m is watching for Java changes on ./src/main/java`);
+  }
 
-    if (chainedExecutable) {
-      return exec(chainedExecutable, chainedArgs, {async: true})
-        .then(process.exit);
-    }
-  })
-  .catch(process.exit);
+  // Run other processes passed through the arguments line
+  const endOfOptionsIndex = process.argv.indexOf('--');
+  const [chainedExecutable, ...chainedArgs] = endOfOptionsIndex > -1
+    ? process.argv.slice(endOfOptionsIndex + 1)
+    : [];
+
+  if (chainedExecutable) {
+    return exec(chainedExecutable, chainedArgs, {async: true})
+      .then(process.exit);
+  }
+
+} catch (error) {
+  console.log('\n🚫 \x1b[36mVaadin Connect\x1b[0m \x1b[31;1mUnable to start the backend. Check whether another instance is already running \x1b[0m 🚫\n');
+}

--- a/scripts/start/webpack.js
+++ b/scripts/start/webpack.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const {execFileSync} = require('child_process');
+
+// Concat with appended env variables
+var webpackArgs = ['--mode', 'development', '-w', '--progress'].concat(process.argv.splice(2));
+execFileSync('webpack', webpackArgs, {stdio: 'inherit'});

--- a/scripts/start/webpack.js
+++ b/scripts/start/webpack.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-const {execFileSync} = require('child_process');
-
-// Concat with appended env variables
-var webpackArgs = ['--mode', 'development', '-w', '--progress'].concat(process.argv.splice(2));
-execFileSync('webpack', webpackArgs, {stdio: 'inherit'});

--- a/src/main/resources/banner.txt
+++ b/src/main/resources/banner.txt
@@ -1,0 +1,3 @@
+
+          - V A A D I N   C O N N E C T - 
+                Starter Application

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,8 +166,8 @@ module.exports = (env, argv) => {
             if (first) {
               first = false;
               msg = `\r 🌀  \x1b[36mVaadin Connect\x1b[0m Webpack is watching for changes on ${inputFolder}\n`;
-              if (process.env.BACKEND) {
-                msg += `\n 🚀  \x1b[36mVaadin Connect\x1b[0m Application Ready at \x1b[32m${process.env.BACKEND}\x1b[0m ${emoji}\n`;
+              if (process.env.CONNECT_BACKEND) {
+                msg += `\n 🚀  \x1b[36mVaadin Connect\x1b[0m Application Ready at \x1b[32m${process.env.CONNECT_BACKEND}\x1b[0m ${emoji}\n`;
               }
             } else {
               msg = `\r 🚀  \x1b[36mVaadin Connect\x1b[0m Webpack has reloaded changes. ${emoji}`;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const HtmlWebpackIncludeAssetsPlugin = require('html-webpack-include-assets-plug
 
 // This folder is served as static in a spring-boot installation
 const outputFolder = 'target/classes/META-INF/resources';
+let compilations = 0;
 
 module.exports = (env, argv) => {
   return {
@@ -154,23 +155,25 @@ module.exports = (env, argv) => {
         publicPath: false
       }),
 
+      // Monitor Webpack progress to show a message when in devmode
       new webpack.ProgressPlugin((percentage, message, ...args) => {
         if (percentage === 1) {
-          setTimeout(() => {
-            console.info("================================================================");
-            console.info("Done Webpack compiling!");
-            if(env && env.connectApiBrowser) {
-              console.info("Started API Browser at:", env.connectApiBrowser);
+          if (argv.mode === 'development') {
+            let msg;
+            if (compilations++) {
+              msg = "\rWebpack has re-compiled changes                                          ";
+            } else {
+              msg = "\r=====================================================================";
+              msg += "\nWebpack compilation done! ";
+              msg += (env && env.connectApiBrowser) ? `\nStarted API Browser at: ${env.connectApiBrowser}` : '';
+              msg += (env && env.connectBackend) ? `\nStarted Vaadin Connect application at: ${env.connectBackend}` : '';
+              msg += "\n=====================================================================";
             }
-            if(env && env.connectBackend) {
-              console.info("Started Vaadin Connect application at:", env.connectBackend);
-            }
-            console.info("================================================================");
-          }, 500);
+            console.log(msg);
+          }
         }
       })
 
     ].filter(Boolean)
-
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -152,6 +152,22 @@ module.exports = (env, argv) => {
         append: true,
         resolvePaths: false,
         publicPath: false
+      }),
+
+      new webpack.ProgressPlugin((percentage, message, ...args) => {
+        if (percentage === 1) {
+          setTimeout(() => {
+            console.info("================================================================");
+            console.info("Done Webpack compiling!");
+            if(env && env.connectApiBrowser) {
+              console.info("Started API Browser at:", env.connectApiBrowser);
+            }
+            if(env && env.connectBackend) {
+              console.info("Started Vaadin Connect application at:", env.connectBackend);
+            }
+            console.info("================================================================");
+          }, 500);
+        }
       })
 
     ].filter(Boolean)


### PR DESCRIPTION
fix #70 

The PR mostly addresses 3 issues mentioned in #70.
I put WIP because there are still points which could be improved (but I don't know how to)
* when `npm install` is triggered from maven, the install progress doesn't show, so I used `--loglevel info` to print more output.
* I am passing information from `backend.js` and `apibrowser.js` to the `webpack`  by using `--evn.variable=value`. That's quite tricky which I think it could be improved.  (I tried passing variables using `options.env` in `spawn` but then it will print a very long list of the environment variables).
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-connect/74)
<!-- Reviewable:end -->
