### PR TITLE
Generate a token-signing-key if missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,9 @@
                             <goal>generate-vaadin-client</goal>
                             <!--Generates Vaadin Connect services' modules to ease their method access, happens on generate-resources phase by default-->
                             <goal>generate-connect-modules</goal>
-                        </goals>
+                            <!-- Generate a signing key on the first startup. Allows access tokens to work across server restarts -->
+                            <goal>generate-token-signing-key</goal>
+                         </goals>
                     </execution>
                 </executions>
                 <!--


### PR DESCRIPTION
Allows access token to be re-used after server restart

Fixes https://github.com/vaadin/vaadin-connect/issues/238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-connect/84)
<!-- Reviewable:end -->
