### PR TITLE
make the default login credentials easier to type

### DIFF
--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -39,9 +39,9 @@ describe('starter application', () => {
             throw new Error('Error: missing shadow root on the login form');
           }
           (loginForm.shadowRoot.querySelector('#username') as HTMLInputElement)
-            .value = 'test_login';
+            .value = 'user';
           (loginForm.shadowRoot.querySelector('#password') as HTMLInputElement)
-            .value = 'test_password';
+            .value = 'user';
           (loginForm.shadowRoot.querySelector('#submit') as HTMLButtonElement)
             .click();
         });

--- a/frontend/login-view.ts
+++ b/frontend/login-view.ts
@@ -24,7 +24,7 @@ export class LoginView {
         password: 'Password',
         submit: 'Submit'
       },
-      additionalInformation: '(use test_login and test_password to authenticate)'
+      additionalInformation: '(type user / user to authenticate)'
     };
   }
 

--- a/src/main/java/com/vaadin/connect/starter/StarterOAuthConfiguration.java
+++ b/src/main/java/com/vaadin/connect/starter/StarterOAuthConfiguration.java
@@ -14,8 +14,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  */
 @Configuration
 public class StarterOAuthConfiguration {
-    private static final String TEST_LOGIN = "test_login";
-    private static final String TEST_PASSWORD = "test_password";
+    private static final String TEST_LOGIN = "user";
+    private static final String TEST_PASSWORD = "user";
 
     private final PasswordEncoder encoder;
 


### PR DESCRIPTION
Use 'user' / 'user' instead of 'test_login' / 'test_password' because they are shorter and easier to type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-connect/94)
<!-- Reviewable:end -->
