### PR TITLE
avoid re-defining inherited POM properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
+    <properties>
+        <vaadin.connect.version>0.6.4</vaadin.connect.version>
+    </properties>
+
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
         <repository>
@@ -76,17 +80,6 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8
-        </project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
-        <vaadin.connect.version>0.6.4</vaadin.connect.version>
-    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
It does not bring much value to explicitly set the properties like `project.build.sourceEncoding`, given that they are already defined in the parent POM (spring-boot-starter-parent). Let's make the POM file less verbose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-connect/95)
<!-- Reviewable:end -->
