### PR TITLE
fix: make the comment for the `token-signing-key` property more clear

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,10 +2,12 @@
 # Uncomment and change the values to override the defaults.
 # See VaadinConnectProperties for more details on the parameters.
 
-# The endpoint to send Vaadin Connect requests to – all Vaadin Connect services requests should be sent to that endpoint.
-# For each service, the resulting url to send the request to is composed of the following parts: ${basePath}/${endpoint}/${serviceName}/${serviceMethod}
+# The endpoint to send Vaadin Connect requests to – all Vaadin Connect services
+# requests should be sent to that endpoint. For each service, the resulting url
+# to send the request to is composed of the following parts:
+# ${basePath}/${endpoint}/${serviceName}/${serviceMethod}
 #vaadin.connect.endpoint=/connect
 
-# The key to sign the Json Web Tokens.
-# If not specified, a random one will be automatically generated when the application starts.
+# The shared secret key to sign / verify access tokens.
+# If not specified, a random value is automatically generated during the build.
 #vaadin.connect.auth.token-signing-key=


### PR DESCRIPTION
Make it more clear for the cases when the property value is automatically generated. Avoid the future tense as it looks confusing when the value has been generated already.

Related to vaadin/vaadin-connect#332

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-connect/98)
<!-- Reviewable:end -->
